### PR TITLE
add a workflow to manually trigger a rebase of a PR opened by ipldbot

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(needs.matrix.outputs.targets) }}
-        workflow: [ "go-test", "go-check" ]
+        workflow: [ "autorebase", "go-test", "go-check" ]
     env:
       WORKFLOW_DIR: "workflow-repo"
       FILE: "${{ matrix.workflow }}.yml"
@@ -64,7 +64,11 @@ jobs:
       with:
         commit-message: update ${{ env.FILE }}
         title: update ${{ matrix.workflow }} workflow
-        body: update to https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+        body:  |
+          update to https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+
+          ---
+          You can trigger a rebase by commenting `@ipldbot rebase`.
         token: ${{ secrets.IPLDBOT_GITHUB_TOKEN }}
         committer: ipldbot <ipldbot@users.noreply.github.com>
         author: ipldbot <ipldbot@users.noreply.github.com>

--- a/workflow-templates/autorebase.yml
+++ b/workflow-templates/autorebase.yml
@@ -1,0 +1,22 @@
+# Allow PRs opened by ipldbot to be rebased by commenting "@ipldbot rebase" on the PR.
+
+on: 
+  issue_comment:
+    types: [ created ]
+    
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && github.event.issue.user.login == 'ipldbot' && contains(github.event.comment.body, '@ipldbot rebase')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.IPLDBOT_GITHUB_TOKEN }}
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.IPLDBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This is useful in repositories where the update of a workflow initially
fails, and the problem is subsequently fixed. It's necessary to rebase
the PR updating the workflow to make sure that all tests now actually
pass.

The new workflow (which will distribited to every participating repo)
achieves this by running on every issue comment, and triggers a rebase
if the comment was made on a PR opened by ipldbot, and it contains the
keywords "@ipldbot rebase".