### PR TITLE
add a workflow to automatically merge ipldbot's PRs

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(needs.matrix.outputs.targets) }}
-        workflow: [ "autorebase", "go-test", "go-check" ]
+        workflow: [ "autorebase", "automerge", "go-test", "go-check" ]
     env:
       WORKFLOW_DIR: "workflow-repo"
       FILE: "${{ matrix.workflow }}.yml"

--- a/workflow-templates/automerge.yml
+++ b/workflow-templates/automerge.yml
@@ -1,0 +1,23 @@
+# Automatically merge pull requests opened by ipldbot, as soon as (and only if) all tests pass.
+# This reduces the friction associated with updating with our workflows.
+
+on: [ pull_request ]
+
+jobs:
+  automerge:
+    if: github.event.pull_request.user.login == 'ipldbot'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Wait on tests
+      uses: lewagon/wait-on-check-action@v0.2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 10
+        running-workflow-name: 'automerge' # the name of this job
+    - name: Merge PR
+      uses: pascalgn/automerge-action@v0.13.1
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        MERGE_LABELS: ""
+        MERGE_DELETE_BRANCH: true

--- a/workflow-templates/automerge.yml
+++ b/workflow-templates/automerge.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Wait on tests
-      uses: lewagon/wait-on-check-action@v0.2
+      uses: lewagon/wait-on-check-action@bafe56a6863672c681c3cf671f5e10b20abf2eaa # v0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10
         running-workflow-name: 'automerge' # the name of this job
     - name: Merge PR
-      uses: pascalgn/automerge-action@v0.13.1
+      uses: pascalgn/automerge-action@741c311a47881be9625932b0a0de1b0937aab1ae # v0.13.1
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         MERGE_LABELS: ""


### PR DESCRIPTION
This workflow aims to reduce the overhead of changing on our workflows. For example, we don't want to manually merge ipldbot's PRs that update the Go version every 6 months across all repos.

The `automerge` workflow runs in every participating repo and automatically merges any PR authored by ipldbot, as soon as (and only if) all checks succeed. 