### PR TITLE
use commit hash to include 3rd party GitHub Actions in autorebase

### DIFF
--- a/workflow-templates/autorebase.yml
+++ b/workflow-templates/autorebase.yml
@@ -17,6 +17,6 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.IPLDBOT_GITHUB_TOKEN }}
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.4
+      uses: cirrus-actions/rebase@7cea12ac34ab078fa37e87798d8986185afa7bf2 # v1.4
       env:
         GITHUB_TOKEN: ${{ secrets.IPLDBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Sorry, looks like I forgot that one in #15. 

Looks like we need a GitHub Action to check our GitHub Actions ;) (just kidding)