### PR TITLE
generate a more useful commit message and PR description

### DIFF
--- a/.github/workflows/copy-workflow.yml
+++ b/.github/workflows/copy-workflow.yml
@@ -1,10 +1,11 @@
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    branches: [ master ]
+    types: [ closed ] # IMPORTANT: check the merge status for every job: github.event.pull_request.merged == true
 
 jobs:
   matrix:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set-matrix.outputs.targets }}
@@ -15,6 +16,7 @@ jobs:
           TARGETS=$(jq -c . .github/workflows/config.json)
           echo "::set-output name=targets::$TARGETS"
   copy:
+    if: github.event.pull_request.merged == true
     needs: [ matrix ]
     runs-on: ubuntu-latest
     strategy:
@@ -62,10 +64,10 @@ jobs:
       if: ${{ env.NEEDS_UPDATE == 1 }}
       uses: peter-evans/create-pull-request@v3
       with:
-        commit-message: update ${{ env.FILE }}
-        title: update ${{ matrix.workflow }} workflow
-        body:  |
-          update to https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+        commit-message: "update ${{ env.FILE }}: ${{ github.event.pull_request.title }}"
+        title: "${{ matrix.workflow }}: ${{ github.event.pull_request.title }}"
+        body: |
+          Change introduced by ${{ github.event.pull_request.html_url }}.
 
           ---
           You can trigger a rebase by commenting `@ipldbot rebase`.


### PR DESCRIPTION
Fixes #9.

The PRs we generate in child repositories should be more meaningful. Currently, we just link to the commit SHA in this repo. Instead, we should:

1. link to the PR that introduced the change (in this repo)
2. use the title of the PR in the commit message
3. use the title of the PR in the title of the PR in the child repo

Obviously, this requires us to make all changes to this repo via PRs. This is a good idea anyway. I turned on branch protection for `master` here.

Before:
<img width="930" alt="Screen Shot 2021-02-28 at 17 11 05" src="https://user-images.githubusercontent.com/1478487/109413636-6728cc80-79e9-11eb-8265-60243ac1bac3.png">

After:
<img width="942" alt="Screen Shot 2021-02-28 at 17 18 25" src="https://user-images.githubusercontent.com/1478487/109413643-6ee87100-79e9-11eb-8758-d8cf3a8df1b9.png">
