### PR TITLE
add a workflow to check that 3rd party actions are included by hash

### DIFF
--- a/.github/workflows/check-3rd-party.sh
+++ b/.github/workflows/check-3rd-party.sh
@@ -7,7 +7,7 @@ for line in `sed -ne 's/[[:space:]-]*uses:[[:space:]]*//p' $1 | sed -e 's/\s*#.*
   author=`echo $line | awk -F/ '{print $1}'`
   if [[ $author == "actions" ]]; then continue; fi
   version=`echo $line | awk -F@ '{print $2}' | awk '{print $1}'`
-  if [[ ${#version} != 40 ]]; then
+  if ! [[ "$version" =~ ^[a-f0-9]{40}$ ]]; then
     status=1
     echo "$FILE includes $line and doesn't use commit hash"
   fi

--- a/.github/workflows/check-3rd-party.sh
+++ b/.github/workflows/check-3rd-party.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+FILE=$1
+status=0
+
+while read -r line; do
+  src=`echo $line | sed -E "s/(.*)uses://g" | xargs`
+  author=`echo $src | awk -F/ '{print $1}'`
+  if [ $author == "actions" ]; then continue; fi
+  version=`echo $src | awk -F@ '{print $2}' | awk '{print $1}'`
+  if [ ${#version} != 40 ]; then
+    status=1
+    echo "$FILE includes $src and doesn't use commit hash"
+  fi
+done < <(grep "uses:" $FILE)
+
+exit $status

--- a/.github/workflows/check-3rd-party.sh
+++ b/.github/workflows/check-3rd-party.sh
@@ -3,15 +3,14 @@
 FILE=$1
 status=0
 
-while read -r line; do
-  src=`echo $line | sed -E "s/(.*)uses://g" | xargs`
-  author=`echo $src | awk -F/ '{print $1}'`
+for line in `sed -ne 's/[[:space:]-]*uses:[[:space:]]*//p' $1 | sed -e 's/\s*#.*$//'`; do
+  author=`echo $line | awk -F/ '{print $1}'`
   if [ $author == "actions" ]; then continue; fi
-  version=`echo $src | awk -F@ '{print $2}' | awk '{print $1}'`
+  version=`echo $line | awk -F@ '{print $2}' | awk '{print $1}'`
   if [ ${#version} != 40 ]; then
     status=1
-    echo "$FILE includes $src and doesn't use commit hash"
+    echo "$FILE includes $line and doesn't use commit hash"
   fi
-done < <(grep "uses:" $FILE)
+done 
 
 exit $status

--- a/.github/workflows/check-3rd-party.sh
+++ b/.github/workflows/check-3rd-party.sh
@@ -5,9 +5,9 @@ status=0
 
 for line in `sed -ne 's/[[:space:]-]*uses:[[:space:]]*//p' $1 | sed -e 's/\s*#.*$//'`; do
   author=`echo $line | awk -F/ '{print $1}'`
-  if [ $author == "actions" ]; then continue; fi
+  if [[ $author == "actions" ]]; then continue; fi
   version=`echo $line | awk -F@ '{print $2}' | awk '{print $1}'`
-  if [ ${#version} != 40 ]; then
+  if [[ ${#version} != 40 ]]; then
     status=1
     echo "$FILE includes $line and doesn't use commit hash"
   fi

--- a/.github/workflows/check-3rd-party.yml
+++ b/.github/workflows/check-3rd-party.yml
@@ -1,0 +1,25 @@
+on: [ pull_request ]
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.set-matrix.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: |
+          TARGETS=$(find . -type f -name "*.yml" | sed "s|^\./||" | grep -v workflow-templates/header.yml | jq -R -s -c 'split("\n")[:-1]')
+          echo "::set-output name=targets::$TARGETS"
+  check:
+    needs: [ matrix ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        file: ${{ fromJson(needs.matrix.outputs.targets) }}
+    name: check ${{ matrix.file }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run check
+        run: .github/workflows/check-3rd-party.sh ${{ matrix.file }}


### PR DESCRIPTION
As suggested by @mvdan in https://github.com/ipld/.github/pull/18#pullrequestreview-599396076.

Test failing because the copy workflow hasn't been updated yet (see #21).