### PR TITLE
run go vet and staticcheck in go-check

### DIFF
--- a/workflow-templates/go-check.yml
+++ b/workflow-templates/go-check.yml
@@ -6,8 +6,16 @@ jobs:
     name: Go checks
     steps:
       - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@d9f0e73c0497685d68af8c58280f49fcaf0545ff # v2.5.1
+      - uses: actions/setup-go@v2
         with:
-          version: v1.33
-          args: "--disable-all --enable gofmt,govet"
+          go-version: "1.16.x"
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@be534f007836a777104a15f2456cd1fffd3ddee8 # v2020.2.2
+      - name: go vet
+        run: go vet ./...
+      - name: staticcheck
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        run: |
+          set -o pipefail
+          staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
+


### PR DESCRIPTION
Fixes #6.

Run `go vet` and `staticcheck` without any involvement of golangci-lint. golangci-lint is a quite complicated beast, and we're probably better off just running the tools ourselves.

See https://github.com/marten-seemann-test/target/pull/33 for a demo of this workflow.

This has been blocked by the problems with staticcheck for way too long. I'm now using a regex to fix the output, such that GitHub Annotations will pick up the path. All we need to do is transform `cmd/main.go:5:6: func build is unused (U1000)` to `./cmd/main.go:5:6: func build is unused (U1000)`.